### PR TITLE
fix: finalization for towns devnet

### DIFF
--- a/op-monitorism/fault/monitor.go
+++ b/op-monitorism/fault/monitor.go
@@ -79,7 +79,12 @@ func NewMonitor(ctx context.Context, log log.Logger, m metrics.Factory, cfg CLIC
 	}
 	faultProofWindow, err := l2OO.FinalizationPeriodSeconds(&bind.CallOpts{Context: ctx})
 	if err != nil {
-		return nil, fmt.Errorf("failed to query for finalization window: %w", err)
+		log.Error("failed to query for finalization window, will try another method", "err", err)
+		faultProofWindow, err = l2OO.FINALIZATIONPERIODSECONDS(&bind.CallOpts{Context: ctx})
+		if err != nil {
+			log.Error("failed to query for finalization window with fallback method", "err", err)
+			return nil, fmt.Errorf("failed to query for finalization window: %w", err)
+		}
 	}
 
 	monitor := &Monitor{


### PR DESCRIPTION
https://sepolia.etherscan.io/address/0x5627B89Ec33CEce4D22Cf99d6C775490de31d18D#readProxyContract

unavailable method because l200 is old

```
docker push 001138754299.dkr.ecr.us-west-2.amazonaws.com/op-monitorism:v0.0.10
The push refers to repository [001138754299.dkr.ecr.us-west-2.amazonaws.com/op-monitorism]
4f4fb700ef54: Layer already exists
44cf07d57ee4: Layer already exists
8693f3096d72: Pushed
6244b20e78eb: Pushed
5ed796ff24e6: Pushed
v0.0.10: digest: sha256:5c5c0cf00218c6a6e13825f0c8f7e9c20a3044825359d7718598596466604269 size: 856
```

```
Defaulted container "op-monitorism-fault" out of: op-monitorism-fault, download-configs (init), dependency-health (init)
(1/2) Installing oniguruma (6.9.8-r1)
(2/2) Installing jq (1.6-r4)
Executing busybox-1.36.1-r7.trigger
OK: 9 MiB in 18 packages
t=2025-11-20T19:41:25+0000 lvl=info msg="creating fault monitor..."
t=2025-11-20T19:41:25+0000 lvl=info msg="using provided L2OutputOracle address" address=0x5627B89Ec33CEce4D22Cf99d6C775490de31d18D
t=2025-11-20T19:41:25+0000 lvl=error msg="failed to query for finalization window, will try another method" err="execution reverted"
t=2025-11-20T19:41:25+0000 lvl=info msg="searching for first unfinalized output"
t=2025-11-20T19:41:26+0000 lvl=info msg="first unfinalized output index" index=259538
t=2025-11-20T19:41:26+0000 lvl=info msg="configured starting index" index=259538
t=2025-11-20T19:41:26+0000 lvl=info msg="starting metrics server" host=0.0.0.0 port=7300
t=2025-11-20T19:41:26+0000 lvl=info msg="starting monitor..." loop_interval_ms=60000
t=2025-11-20T19:41:26+0000 lvl=info msg="waiting for next output" index=259538 next_index=259538
```